### PR TITLE
refactor(email): simplify and shorten docstrings in email channel and tests

### DIFF
--- a/tests/test_email_channel.py
+++ b/tests/test_email_channel.py
@@ -18,19 +18,7 @@ class _FakeSMTPClient:
         timeout: int = 30,
         context: ssl.SSLContext | None = None,
     ) -> None:
-        """
-        Initialize the fake SMTP client used by tests.
-
-        Parameters:
-            _host (str): SMTP server host (stored for reference; not used to connect).
-            _port (int): SMTP server port (stored for reference; not used to connect).
-            timeout (int): Socket/operation timeout in seconds.
-            context (ssl.SSLContext | None): Optional TLS/SSL context to use for connections.
-            on_init (Callable[[], None] | None): Optional callback invoked immediately after initialization.
-
-        The instance exposes these attributes for test assertions: `timeout`, `context`,
-        `started_tls`, `starttls_context`, `logged_in`, and `sent_messages`.
-        """
+        """Store call metadata and state flags for SMTP assertions."""
         self.timeout = timeout
         self.context = context
         self.started_tls = False
@@ -39,62 +27,24 @@ class _FakeSMTPClient:
         self.sent_messages: list[EmailMessage] = []
 
     def __enter__(self):
-        """
-        Enter the context manager and provide the fake SMTP client instance.
-
-        Returns:
-            self: The fake SMTP client instance.
-        """
         return self
 
     def __exit__(self, exc_type, exc, tb):
-        """
-        Context manager exit that does not suppress exceptions.
-
-        @returns `False` to indicate any exception raised in the with-block should be propagated.
-        """
         return False
 
     def starttls(self, context=None):
-        """
-        Mark that a STARTTLS handshake has been performed and record the TLS context.
-
-        Parameters:
-            context (ssl.SSLContext | None): The SSL context provided for STARTTLS; may be None if no context was supplied.
-        """
         self.started_tls = True
         self.starttls_context = context
 
     def login(self, _user: str, _pw: str):
-        """
-        Mark the client as authenticated.
-
-        Parameters:
-            _user (str): Ignored; present for API compatibility.
-            _pw (str): Ignored; present for API compatibility.
-
-        Details:
-            Sets the instance's `logged_in` flag to True.
-        """
         self.logged_in = True
 
     def send_message(self, msg: EmailMessage):
-        """
-        Record an outgoing EmailMessage for inspection by tests.
-
-        Parameters:
-            msg (EmailMessage): The email message to append to this client's sent_messages list for later verification.
-        """
         self.sent_messages.append(msg)
 
 
 def _make_config() -> EmailConfig:
-    """
-    Create a populated EmailConfig suitable for unit tests.
-
-    Returns:
-        EmailConfig: Configuration with enabled and consent_granted set to True, IMAP pointing to imap.example.com:993 with username "bot@example.com", SMTP pointing to smtp.example.com:587 with the same credentials, and mark_seen set to True.
-    """
+    """Create a baseline EmailConfig used across tests."""
     return EmailConfig(
         enabled=True,
         consent_granted=True,
@@ -162,27 +112,12 @@ def test_fetch_new_messages_parses_unseen_and_marks_seen(monkeypatch) -> None:
             return "OK", [b""]
 
         def logout(self):
-            """
-            Simulate an IMAP logout response.
-
-            Returns:
-                tuple: A (response, data) tuple where `response` is the string "BYE" and `data` is a list containing an empty bytes object (i.e., [b""]).
-            """
             return "BYE", [b""]
 
     fake = FakeIMAP()
     captured: dict[str, ssl.SSLContext | None] = {"ssl_context": None}
 
     def _imap_factory(_host: str, _port: int, ssl_context: ssl.SSLContext | None = None):
-        """
-        Test IMAP connection factory that records the SSL context passed to it for inspection.
-
-        Parameters:
-            ssl_context (ssl.SSLContext | None): The SSL context provided to the IMAP constructor; recorded in the enclosing `captured` mapping for test assertions.
-
-        Returns:
-            fake: A preconstructed fake IMAP client used by tests.
-        """
         captured["ssl_context"] = ssl_context
         return fake
 
@@ -358,27 +293,12 @@ def test_fetch_messages_between_dates_uses_imap_since_before_without_mark_seen(m
             return "OK", [b""]
 
         def logout(self):
-            """
-            Simulate an IMAP logout response.
-
-            Returns:
-                tuple: A (response, data) tuple where `response` is the string "BYE" and `data` is a list containing an empty bytes object (i.e., [b""]).
-            """
             return "BYE", [b""]
 
     fake = FakeIMAP()
     captured: dict[str, ssl.SSLContext | None] = {"ssl_context": None}
 
     def _imap_factory(_host: str, _port: int, ssl_context: ssl.SSLContext | None = None):
-        """
-        Test IMAP connection factory that records the SSL context passed to it for inspection.
-
-        Parameters:
-            ssl_context (ssl.SSLContext | None): The SSL context provided to the IMAP constructor; recorded in the enclosing `captured` mapping for test assertions.
-
-        Returns:
-            fake: A preconstructed fake IMAP client used by tests.
-        """
         captured["ssl_context"] = ssl_context
         return fake
 
@@ -412,18 +332,6 @@ async def test_send_uses_smtp_ssl_with_verified_context_by_default(monkeypatch) 
         timeout: int = 30,
         context: ssl.SSLContext | None = None,
     ):
-        """
-        Create a test SMTP client and record it in the module-level `fake_instances` list.
-
-        Parameters:
-            host (str): SMTP server hostname passed to the fake client.
-            port (int): SMTP server port passed to the fake client.
-            timeout (int): Connection timeout in seconds.
-            context (ssl.SSLContext | None): Optional SSL context to use for the fake client.
-
-        Returns:
-            _FakeSMTPClient: The created fake SMTP client instance.
-        """
         instance = _FakeSMTPClient(host, port, timeout=timeout, context=context)
         fake_instances.append(instance)
         return instance
@@ -455,16 +363,6 @@ def test_tls_verify_false_uses_unverified_context_and_logs_once(monkeypatch) -> 
     warnings: list[str] = []
 
     def _warn(msg: str, *args):
-        """
-        Record a formatted warning message into the module-level warnings list.
-
-        Parameters:
-            msg (str): Format string for the warning message.
-            *args: Optional values to format into `msg` using `str.format`.
-
-        Notes:
-            Appends the formatted (or raw) message to the `warnings` list defined in the surrounding scope.
-        """
         if args:
             warnings.append(msg.format(*args))
         else:


### PR DESCRIPTION
Simplify docstrings in email channel. No need for full-fledged docstrings including parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added intelligent message deduplication per chat to prevent reprocessing identical emails
  * Enhanced TLS/SSL security with improved connection handling, certificate verification, and warnings for insecure configurations
  * Improved email conversation threading with better tracking of subject lines and message references for accurate replies

<!-- end of auto-generated comment: release notes by coderabbit.ai -->