### PR TITLE
docs(core): add high-signal docstrings and codify docstring policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,10 @@ Context7 Library IDs for this project (use to skip library-matching):
 - Follow Ruff settings in `pyproject.toml` (line length 100, rules `E,F,I,N,W`).
 - Keep features in the matching package (for example, channel logic in `nanobot/channels/`, provider logic in `nanobot/providers/`).
 - Prefer explicit, readable control flow over framework-style indirection or hidden magic.
+- Keep docstrings high-signal and lightweight: document public APIs and non-obvious behavior.
+- Do not add docstrings for trivial `name`/`description`/`parameters` properties or obvious magic methods.
+- Keep docstrings short (usually 1-2 sentences) and focus on side effects, security behavior, and invariants.
+- Avoid broad docstring-only churn; make docstring edits when they improve clarity for maintained code paths.
 
 ## Testing Guidelines
 

--- a/nanobot/agent/context.py
+++ b/nanobot/agent/context.py
@@ -21,6 +21,7 @@ class ContextBuilder:
     BOOTSTRAP_FILES = ["AGENTS.md", "SOUL.md", "USER.md", "TOOLS.md", "IDENTITY.md"]
 
     def __init__(self, workspace: Path):
+        """Initialize memory/skill loaders bound to the given workspace path."""
         self.workspace = workspace
         self.memory = MemoryStore(workspace)
         self.skills = SkillsLoader(workspace)

--- a/nanobot/agent/loop.py
+++ b/nanobot/agent/loop.py
@@ -64,6 +64,7 @@ class AgentLoop:
         session_manager: SessionManager | None = None,
         mcp_servers: dict | None = None,
     ):
+        """Wire core agent dependencies, runtime settings, and the tool registry."""
         from nanobot.config.schema import ExecToolConfig, WebSearchConfig
         self.bus = bus
         self.provider = provider

--- a/nanobot/agent/memory.py
+++ b/nanobot/agent/memory.py
@@ -9,22 +9,27 @@ class MemoryStore:
     """Two-layer memory: MEMORY.md (long-term facts) + HISTORY.md (grep-searchable log)."""
 
     def __init__(self, workspace: Path):
+        """Initialize memory file locations under `<workspace>/memory`."""
         self.memory_dir = ensure_dir(workspace / "memory")
         self.memory_file = self.memory_dir / "MEMORY.md"
         self.history_file = self.memory_dir / "HISTORY.md"
 
     def read_long_term(self) -> str:
+        """Read `MEMORY.md`; return an empty string when the file is missing."""
         if self.memory_file.exists():
             return self.memory_file.read_text(encoding="utf-8")
         return ""
 
     def write_long_term(self, content: str) -> None:
+        """Overwrite `MEMORY.md` with the provided long-term memory content."""
         self.memory_file.write_text(content, encoding="utf-8")
 
     def append_history(self, entry: str) -> None:
+        """Append one entry to `HISTORY.md`, normalized to a blank-line separator."""
         with open(self.history_file, "a", encoding="utf-8") as f:
             f.write(entry.rstrip() + "\n\n")
 
     def get_memory_context(self) -> str:
+        """Return formatted long-term memory text suitable for prompt injection."""
         long_term = self.read_long_term()
         return f"## Long-term Memory\n{long_term}" if long_term else ""

--- a/nanobot/agent/skills.py
+++ b/nanobot/agent/skills.py
@@ -19,6 +19,7 @@ class SkillsLoader:
     """
 
     def __init__(self, workspace: Path, builtin_skills_dir: Path | None = None):
+        """Configure workspace and built-in skill directories for resolution precedence."""
         self.workspace = workspace
         self.workspace_skills = workspace / "skills"
         self.builtin_skills = builtin_skills_dir or BUILTIN_SKILLS_DIR

--- a/nanobot/agent/subagent.py
+++ b/nanobot/agent/subagent.py
@@ -47,6 +47,7 @@ class SubagentManager:
         exec_config: ExecToolConfig | None = None,
         restrict_to_workspace: bool = False,
     ):
+        """Store shared runtime dependencies and defaults for spawned subagents."""
         from nanobot.config.schema import ExecToolConfig
         self.provider = provider
         self.workspace = workspace

--- a/nanobot/agent/tools/cron.py
+++ b/nanobot/agent/tools/cron.py
@@ -11,6 +11,7 @@ class CronTool(Tool):
     """Tool to schedule reminders and recurring tasks."""
 
     def __init__(self, cron_service: CronService):
+        """Initialize the tool with a cron backend and empty delivery context."""
         self._cron = cron_service
         self._channel = ""
         self._chat_id = ""
@@ -72,6 +73,7 @@ class CronTool(Tool):
         job_id: str | None = None,
         **kwargs: Any
     ) -> str:
+        """Dispatch cron actions (`add`, `list`, `remove`) and return a user-facing status."""
         if action == "add":
             return self._add_job(message, every_seconds, cron_expr, at)
         elif action == "list":

--- a/nanobot/agent/tools/filesystem.py
+++ b/nanobot/agent/tools/filesystem.py
@@ -21,6 +21,7 @@ class ReadFileTool(Tool):
     """Tool to read file contents."""
 
     def __init__(self, allowed_dir: Path | None = None):
+        """Optionally restrict readable paths to the configured directory subtree."""
         self._allowed_dir = allowed_dir
 
     @property
@@ -45,6 +46,7 @@ class ReadFileTool(Tool):
         }
 
     async def execute(self, path: str, **kwargs: Any) -> str:
+        """Read and return UTF-8 file content for `path` with basic safety checks."""
         try:
             file_path = _resolve_path(path, self._allowed_dir)
             if not file_path.exists():
@@ -64,6 +66,7 @@ class WriteFileTool(Tool):
     """Tool to write content to a file."""
 
     def __init__(self, allowed_dir: Path | None = None):
+        """Optionally restrict writable paths to the configured directory subtree."""
         self._allowed_dir = allowed_dir
 
     @property
@@ -92,6 +95,7 @@ class WriteFileTool(Tool):
         }
 
     async def execute(self, path: str, content: str, **kwargs: Any) -> str:
+        """Write UTF-8 `content` to `path`, creating parent directories when needed."""
         try:
             file_path = _resolve_path(path, self._allowed_dir)
             file_path.parent.mkdir(parents=True, exist_ok=True)
@@ -107,6 +111,7 @@ class EditFileTool(Tool):
     """Tool to edit a file by replacing text."""
 
     def __init__(self, allowed_dir: Path | None = None):
+        """Optionally restrict editable paths to the configured directory subtree."""
         self._allowed_dir = allowed_dir
 
     @property
@@ -139,6 +144,7 @@ class EditFileTool(Tool):
         }
 
     async def execute(self, path: str, old_text: str, new_text: str, **kwargs: Any) -> str:
+        """Replace one exact `old_text` occurrence in `path` with `new_text`."""
         try:
             file_path = _resolve_path(path, self._allowed_dir)
             if not file_path.exists():
@@ -168,6 +174,7 @@ class ListDirTool(Tool):
     """Tool to list directory contents."""
 
     def __init__(self, allowed_dir: Path | None = None):
+        """Optionally restrict listed paths to the configured directory subtree."""
         self._allowed_dir = allowed_dir
 
     @property
@@ -192,6 +199,7 @@ class ListDirTool(Tool):
         }
 
     async def execute(self, path: str, **kwargs: Any) -> str:
+        """List directory entries for `path` with a simple file/dir marker prefix."""
         try:
             dir_path = _resolve_path(path, self._allowed_dir)
             if not dir_path.exists():
@@ -218,6 +226,7 @@ class DeleteFileTool(Tool):
     """Tool to delete a file."""
 
     def __init__(self, allowed_dir: Path | None = None):
+        """Optionally restrict deletion targets to the configured directory subtree."""
         self._allowed_dir = allowed_dir
 
     @property
@@ -242,6 +251,7 @@ class DeleteFileTool(Tool):
         }
 
     async def execute(self, path: str, **kwargs: Any) -> str:
+        """Delete a file or symlink at `path`, blocking workspace-escape attempts."""
         try:
             # Keep lexical path (no resolve) so symlink entries can be deleted as links.
             file_path = Path(os.path.abspath(str(Path(path).expanduser())))

--- a/nanobot/agent/tools/mcp.py
+++ b/nanobot/agent/tools/mcp.py
@@ -13,6 +13,7 @@ class MCPToolWrapper(Tool):
     """Wraps a single MCP server tool as a nanobot Tool."""
 
     def __init__(self, session, server_name: str, tool_def):
+        """Map one MCP tool definition to a namespaced nanobot tool wrapper."""
         self._session = session
         self._original_name = tool_def.name
         self._name = f"mcp_{server_name}_{tool_def.name}"
@@ -32,6 +33,7 @@ class MCPToolWrapper(Tool):
         return self._parameters
 
     async def execute(self, **kwargs: Any) -> str:
+        """Call the underlying MCP tool and flatten structured content into plain text."""
         from mcp import types
         result = await self._session.call_tool(self._original_name, arguments=kwargs)
         parts = []

--- a/nanobot/agent/tools/message.py
+++ b/nanobot/agent/tools/message.py
@@ -15,6 +15,7 @@ class MessageTool(Tool):
         default_channel: str = "",
         default_chat_id: str = "",
     ):
+        """Initialize optional send callback plus default routing context."""
         self._send_callback = send_callback
         self._default_channel = default_channel
         self._default_chat_id = default_chat_id
@@ -67,6 +68,7 @@ class MessageTool(Tool):
         media: list[str] | None = None,
         **kwargs: Any,
     ) -> str:
+        """Send a message to the resolved channel/chat target with optional media paths."""
         channel = channel or self._default_channel
         chat_id = chat_id or self._default_chat_id
 

--- a/nanobot/agent/tools/registry.py
+++ b/nanobot/agent/tools/registry.py
@@ -13,6 +13,7 @@ class ToolRegistry:
     """
 
     def __init__(self):
+        """Initialize an empty in-memory registry keyed by tool name."""
         self._tools: dict[str, Tool] = {}
 
     def register(self, tool: Tool) -> None:

--- a/nanobot/agent/tools/shell.py
+++ b/nanobot/agent/tools/shell.py
@@ -20,6 +20,7 @@ class ExecTool(Tool):
         allow_patterns: list[str] | None = None,
         restrict_to_workspace: bool = False,
     ):
+        """Configure execution timeout, command guards, and optional workspace restriction."""
         self.timeout = timeout
         self.working_dir = working_dir
         self.deny_patterns = deny_patterns or [
@@ -77,6 +78,7 @@ class ExecTool(Tool):
         }
 
     async def execute(self, command: str, working_dir: str | None = None, **kwargs: Any) -> str:
+        """Run a guarded shell command and return captured stdout/stderr text."""
         cwd = working_dir or self.working_dir or os.getcwd()
         guard_error = self._guard_command(command, cwd)
         if guard_error:

--- a/nanobot/agent/tools/spawn.py
+++ b/nanobot/agent/tools/spawn.py
@@ -17,6 +17,7 @@ class SpawnTool(Tool):
     """
 
     def __init__(self, manager: "SubagentManager"):
+        """Bind the tool to a subagent manager and initialize origin routing defaults."""
         self._manager = manager
         self._origin_channel = "cli"
         self._origin_chat_id = "direct"

--- a/nanobot/agent/tools/web.py
+++ b/nanobot/agent/tools/web.py
@@ -84,6 +84,7 @@ class WebSearchTool(Tool):
         transport: httpx.AsyncBaseTransport | None = None,
         ddgs_factory: Callable[[], DDGS] | None = None,
     ):
+        """Initialize provider config, HTTP transport hooks, and provider dispatch map."""
         from nanobot.config.schema import WebSearchConfig
 
         self.config = config if config is not None else WebSearchConfig()
@@ -97,6 +98,7 @@ class WebSearchTool(Tool):
         }
 
     async def execute(self, query: str, count: int | None = None, **kwargs: Any) -> str:
+        """Run a web search via the configured provider and return formatted results."""
         provider = (self.config.provider or "brave").strip().lower()
         n = min(max(count or self.config.max_results, 1), 10)
 
@@ -223,6 +225,7 @@ class WebFetchTool(Tool):
     }
 
     def __init__(self, max_chars: int = 50000):
+        """Set the maximum output length for extracted page content."""
         self.max_chars = max_chars
 
     async def execute(
@@ -232,6 +235,7 @@ class WebFetchTool(Tool):
         max_chars: int | None = None,
         **kwargs: Any,
     ) -> str:
+        """Fetch one URL, extract readable content, and return a structured JSON payload."""
         from readability import Document
 
         if isinstance(kwargs.get("extractMode"), str):

--- a/nanobot/bus/queue.py
+++ b/nanobot/bus/queue.py
@@ -17,6 +17,7 @@ class MessageBus:
     """
 
     def __init__(self):
+        """Create inbound/outbound queues and subscriber state for dispatcher mode."""
         self.inbound: asyncio.Queue[InboundMessage] = asyncio.Queue()
         self.outbound: asyncio.Queue[OutboundMessage] = asyncio.Queue()
         self._outbound_subscribers: dict[str, list[Callable[[OutboundMessage], Awaitable[None]]]] = {}

--- a/nanobot/channels/manager.py
+++ b/nanobot/channels/manager.py
@@ -23,6 +23,7 @@ class ChannelManager:
     """
 
     def __init__(self, config: Config, bus: MessageBus):
+        """Initialize channel registry from config and wire it to the shared message bus."""
         self.config = config
         self.bus = bus
         self.channels: dict[str, BaseChannel] = {}

--- a/nanobot/channels/matrix.py
+++ b/nanobot/channels/matrix.py
@@ -1,3 +1,5 @@
+"""Matrix channel implementation for inbound sync and outbound message/media delivery."""
+
 import asyncio
 import logging
 import mimetypes
@@ -238,6 +240,7 @@ class MatrixChannel(BaseChannel):
         restrict_to_workspace: bool = False,
         workspace: Path | None = None,
     ):
+        """Store Matrix client settings, task handles, and outbound media policy flags."""
         super().__init__(config, bus)
         self.client: AsyncClient | None = None
         self._sync_task: asyncio.Task | None = None
@@ -603,6 +606,7 @@ class MatrixChannel(BaseChannel):
         return None
 
     async def send(self, msg: OutboundMessage) -> None:
+        """Send message text and optional attachments to a Matrix room, then clear typing state."""
         if not self.client:
             return
 

--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -149,6 +149,7 @@ async def _read_interactive_input_async() -> str:
 
 
 def version_callback(value: bool):
+    """Print version and exit when `--version`/`-v` is provided."""
     if value:
         console.print(f"{__logo__} nanobot v{__version__}")
         raise typer.Exit()

--- a/nanobot/cron/service.py
+++ b/nanobot/cron/service.py
@@ -53,6 +53,7 @@ class CronService:
         store_path: Path,
         on_job: Callable[[CronJob], Coroutine[Any, Any, str | None]] | None = None
     ):
+        """Initialize persistence path, optional execution callback, and runtime state."""
         self.store_path = store_path
         self.on_job = on_job  # Callback to execute job, returns response text
         self._store: CronStore | None = None

--- a/nanobot/heartbeat/service.py
+++ b/nanobot/heartbeat/service.py
@@ -50,6 +50,7 @@ class HeartbeatService:
         interval_s: int = DEFAULT_HEARTBEAT_INTERVAL_S,
         enabled: bool = True,
     ):
+        """Configure heartbeat workspace, callback, cadence, and enabled state."""
         self.workspace = workspace
         self.on_heartbeat = on_heartbeat
         self.interval_s = interval_s
@@ -59,6 +60,7 @@ class HeartbeatService:
 
     @property
     def heartbeat_file(self) -> Path:
+        """Return the `HEARTBEAT.md` path in the configured workspace."""
         return self.workspace / "HEARTBEAT.md"
 
     def _read_heartbeat_file(self) -> str | None:

--- a/nanobot/providers/base.py
+++ b/nanobot/providers/base.py
@@ -37,6 +37,7 @@ class LLMProvider(ABC):
     """
 
     def __init__(self, api_key: str | None = None, api_base: str | None = None):
+        """Store provider credentials/endpoints shared by concrete implementations."""
         self.api_key = api_key
         self.api_base = api_base
 

--- a/nanobot/providers/litellm_provider.py
+++ b/nanobot/providers/litellm_provider.py
@@ -28,6 +28,7 @@ class LiteLLMProvider(LLMProvider):
         extra_headers: dict[str, str] | None = None,
         provider_name: str | None = None,
     ):
+        """Initialize gateway/provider detection and LiteLLM runtime configuration."""
         super().__init__(api_key, api_base)
         self.default_model = default_model
         self.extra_headers = extra_headers or {}

--- a/nanobot/providers/openai_codex_provider.py
+++ b/nanobot/providers/openai_codex_provider.py
@@ -23,6 +23,7 @@ class OpenAICodexProvider(LLMProvider):
     def __init__(
         self, default_model: str = "openai-codex/gpt-5.2-codex", ssl_verify: bool = True
     ):
+        """Configure default Codex model and TLS certificate verification behavior."""
         super().__init__(api_key=None, api_base=None)
         self.default_model = default_model
         self.ssl_verify = ssl_verify

--- a/nanobot/providers/transcription.py
+++ b/nanobot/providers/transcription.py
@@ -15,6 +15,7 @@ class GroqTranscriptionProvider:
     """
 
     def __init__(self, api_key: str | None = None):
+        """Initialize Groq credentials and fixed transcription endpoint URL."""
         self.api_key = api_key or os.environ.get("GROQ_API_KEY")
         self.api_url = "https://api.groq.com/openai/v1/audio/transcriptions"
 

--- a/nanobot/session/manager.py
+++ b/nanobot/session/manager.py
@@ -60,6 +60,7 @@ class SessionManager:
     """
 
     def __init__(self, workspace: Path):
+        """Initialize session storage paths and an in-memory session cache."""
         self.workspace = workspace
         self.sessions_dir = ensure_dir(Path.home() / ".nanobot" / "sessions")
         self._cache: dict[str, Session] = {}


### PR DESCRIPTION
Add concise, behavior-focused docstrings across core modules where they improve
operational clarity (constructors, orchestration paths, I/O and security-relevant
methods), while intentionally avoiding trivial getter/property boilerplate.

Also update AGENTS.md with explicit docstring rules aligned to redux goals:
keep docstrings lightweight, prefer high-signal API docs, and avoid broad
docstring-only churn without clear value.

No runtime behavior changes.

Verification:
- ruff check .
- ruff check nanobot --select D100,D101,D102,D103,D104,D105,D106,D107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive docstrings to agent components, tools, services, and providers to improve code clarity and maintainability.
  * Established new docstring guidelines emphasizing high-signal documentation for public APIs and non-obvious behavior while avoiding trivial comments.
  * Enhanced documentation across initialization methods and core operations throughout the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->