### PR TITLE
docs: split upstream-log into upstream and fork-specific tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Context7 Library IDs for this project (use to skip library-matching):
 
 - `nanobot/` contains the Python app code (agent loop, tools, channels, providers, CLI, config, cron, heartbeat, session, skills).
 - `tests/` contains `pytest` suites plus `test_docker.sh` for container smoke testing.
-- `docs/` stores feature/configuration docs plus fork governance docs (`docs/redux-manifest.md`, `docs/upstream-intake.md`, `docs/upstream-log.md`, `docs/release-template.md`).
+- `docs/` stores feature/configuration docs plus fork governance docs (`docs/redux-manifest.md`, `docs/upstream-intake.md`, `docs/upstream-log.md`, `docs/redux-changes.md`, `docs/release-template.md`).
 - `workspace/` is runtime workspace content (agent notes/memory) and is not core library code.
 - Root files include packaging/config (`pyproject.toml`), container setup (`Dockerfile`), and project docs (`README.md`, `SECURITY.md`).
 
@@ -100,6 +100,7 @@ Context7 Library IDs for this project (use to skip library-matching):
 - Prefer selective cherry-picks over broad merges.
 - For each adopted upstream change, add an entry in `docs/upstream-log.md` with upstream link, area, rationale, risk, adoption date, and verification command(s).
 - For deferred or rejected upstream changes, record concise reasons in `docs/upstream-log.md`.
+- For fork-specific changes (not adopted from upstream), add an entry in `docs/redux-changes.md` with PR/commit link, area, rationale, risk, date, and verification command(s).
 - When preparing a release, use `docs/release-template.md`.
 
 ## Security & Configuration Tips

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ This fork is based on **[HKUDS/nanobot v0.1.3.post7](https://github.com/HKUDS/na
 **Install from source** (latest features, recommended for development)
 
 ```bash
-git clone https://github.com/HKUDS/nanobot.git
-cd nanobot
+git clone https://github.com/Athemis/nanobot-redux.git
+cd nanobot-redux
 pip install -e .
 ```
 
@@ -500,9 +500,17 @@ Interactive mode exits: `exit`, `quit`, `/exit`, `/quit`, `:q`, or `Ctrl+D`.
 <summary><b>Scheduled Tasks (Cron)</b></summary>
 
 ```bash
-# Add a job
+# Add a recurring job (cron expression)
 nanobot cron add --name "daily" --message "Good morning!" --cron "0 9 * * *"
+
+# Add a timezone-aware job (IANA timezone)
+nanobot cron add --name "daily-berlin" --message "Good morning!" --cron "0 9 * * *" --tz "Europe/Berlin"
+
+# Add an interval job
 nanobot cron add --name "hourly" --message "Check status" --every 3600
+
+# Add a one-time reminder
+nanobot cron add --name "meeting" --message "Meeting now!" --at "2099-01-01T15:00:00"
 
 # List jobs
 nanobot cron list
@@ -510,6 +518,8 @@ nanobot cron list
 # Remove a job
 nanobot cron remove <job_id>
 ```
+
+> Jobs added via `nanobot cron add` while the gateway is running are picked up automatically within ≤5 minutes (mtime polling, no restart required).
 
 </details>
 
@@ -574,6 +584,23 @@ I try to keep these compatible so I don't break my own setup:
 - Python package stays `nanobot.*`
 - Config lives in `~/.nanobot/*`
 
+### What This Fork Adds
+
+Changes that are specific to this fork and not in upstream:
+
+**Cron scheduler**
+- Hot-reload: jobs added via `nanobot cron add` while the gateway runs are picked up within ≤5 minutes — no restart needed ([#22](https://github.com/Athemis/nanobot-redux/pull/22))
+- Cron loop is resilient to disk errors — `OSError` in `_save_store` no longer kills the timer task permanently ([#22](https://github.com/Athemis/nanobot-redux/pull/22))
+
+**Security hardening**
+- Codex provider: TLS verification is on by default; `sslVerify=false` must be set explicitly, preventing silent MITM exposure on corporate proxies
+- Codex provider: SSE error payloads (`error`, `response.failed`) are surfaced as diagnostic messages instead of generic failure text
+- Codex provider: `max_output_tokens`/`max_tokens` omitted from OAuth payloads (the endpoint rejects them — fixes actual API failures)
+- Email channel: plaintext SMTP (both `smtpUseTls` and `smtpUseSsl` disabled) is refused at send time; `tlsVerify` defaults to `true` with explicit opt-out
+
+**Agent reliability**
+- Subagent skill access: builtin skills are always readable even when `tools.restrictToWorkspace=true` — previously subagents silently lost access to all skills in restricted mode
+
 ### Philosophy
 
 - Keep channels stable, debuggable, and easy to self-host
@@ -596,7 +623,8 @@ For technical details on upstream intake, adoption criteria, and release process
 
 - [`docs/redux-manifest.md`](docs/redux-manifest.md) - Fork philosophy and priorities
 - [`docs/upstream-intake.md`](docs/upstream-intake.md) - How I evaluate upstream changes
-- [`docs/upstream-log.md`](docs/upstream-log.md) - History of adopted features
+- [`docs/upstream-log.md`](docs/upstream-log.md) - Upstream adoptions, deferrals, and rejections
+- [`docs/redux-changes.md`](docs/redux-changes.md) - Changes originating in this fork
 - [`docs/release-template.md`](docs/release-template.md) - Release checklist
 
 ## 🤝 Contributing

--- a/docs/redux-changes.md
+++ b/docs/redux-changes.md
@@ -1,0 +1,49 @@
+# Redux Changes
+
+This file tracks changes that originate in this fork — not adopted from upstream, but developed here. It's a record of why decisions were made and how to verify them.
+
+See [`docs/upstream-log.md`](upstream-log.md) for upstream adoptions.
+
+## Changes
+
+| Change | PR/Commit | Area | Why | Risk | Added | Verification |
+| ------ | --------- | ---- | --- | ---- | ----- | ------------ |
+| OpenClaw skill metadata regression tests | [9290f23](https://github.com/Athemis/nanobot-redux/commit/9290f23879df58cec39671b2cf984be23e1915fb) | Skills loader | Lock in fork behavior for `openclaw` metadata support and `nanobot` precedence when both keys exist | low | 2026-02-16 | `pytest tests/test_skills_loader.py` |
+| Codex TLS verification hardening | [3d0d1eb](https://github.com/Athemis/nanobot-redux/commit/3d0d1ebdf2e711dce527b4b3ed2ddee2612734ca) | Codex Provider | Avoid silent TLS downgrade; require explicit `providers.openaiCodex.sslVerify=false` opt-in | low | 2026-02-16 | `pytest -q tests/test_config_loader_conversion.py tests/test_generation_params.py tests/test_onboard_openrouter_defaults.py` + `ruff check nanobot/config/schema.py nanobot/cli/commands.py nanobot/providers/openai_codex_provider.py` |
+| Codex SSE error diagnostics | [2a77f20](https://github.com/Athemis/nanobot-redux/commit/2a77f20c2b91136ab9dabc11df063b4502dedc8d) | Codex Provider | Surface provider error details from `error`/`response.failed` payloads instead of generic failure text | low | 2026-02-16 | `pytest -q tests/test_generation_params.py` + `ruff check nanobot/providers/openai_codex_provider.py` |
+| Codex OAuth token-limit compatibility | [#16](https://github.com/Athemis/nanobot-redux/pull/16), [#17](https://github.com/Athemis/nanobot-redux/issues/17) | Codex Provider | `chatgpt.com/backend-api/codex/responses` rejects unsupported token-limit parameters; align payload with OpenAI Codex OAuth request shape that omits `max_output_tokens`/`max_tokens` | low | 2026-02-17 | `pytest -q tests/test_generation_params.py -k codex` + `ruff check nanobot/providers/openai_codex_provider.py` |
+| Email TLS verification hardening + plaintext SMTP block | [#6](https://github.com/Athemis/nanobot-redux/pull/6) | Email channel | Enforce explicit TLS verification by default with explicit opt-out warning (`channels.email.tlsVerify`), and refuse SMTP sends when both `smtpUseTls` and `smtpUseSsl` are disabled | medium | 2026-02-16 | `pytest -q tests/test_email_channel.py` + `ruff check nanobot/channels/email.py tests/test_email_channel.py nanobot/config/schema.py` |
+| Subagent skill access in workspace-restricted mode | [#18](https://github.com/Athemis/nanobot-redux/pull/18) | Agent / Skills | Subagents couldn't read builtin skills when `restrictToWorkspace` was enabled; `ReadFileTool` gains `extra_allowed_dirs` allowlist so `BUILTIN_SKILLS_DIR` is always readable; subagent prompt updated to surface available skills | low | 2026-02-17 | `pytest -q tests/test_read_file_tool.py` + `ruff check nanobot/agent/subagent.py nanobot/agent/tools/filesystem.py` |
+| Agentic prompt hardening | [#18](https://github.com/Athemis/nanobot-redux/pull/18) | Agent prompts | Skill-trigger wording, loop-continuation nudge, heartbeat prompt, spawn tool description, and workspace docs rewritten to push the agent toward direct action over passive confirmation-seeking | low | 2026-02-17 | `ruff check nanobot/agent/loop.py nanobot/agent/context.py nanobot/agent/tools/spawn.py nanobot/heartbeat/service.py` |
+| CI lint enforcement | [e3128af](https://github.com/Athemis/nanobot-redux/commit/e3128af28bb7bccd455be70900152efc18379b44) | CI | `ruff check` failures now cause the test workflow to fail; previously lint errors were reported but did not block merges | low | 2026-02-16 | `.github/workflows/tests.yml` |
+| Cron mtime hot-reload | [#22](https://github.com/Athemis/nanobot-redux/pull/22) | Cron service | `nanobot cron add` (CLI) writes only to disk; the running gateway never reloaded its in-memory store, so externally added jobs were silently skipped. Adds `_store_mtime` tracking, `_check_disk_changes()`, and a `_POLL_INTERVAL_S=300` cap on `_arm_timer` — fixes both the empty-store case (no timer at all) and the far-future-job case (timer would fire too late). No new dependencies. See rejected [HKUDS/nanobot#788](https://github.com/HKUDS/nanobot/pull/788) for the watchdog alternative. | low | 2026-02-18 | `pytest tests/test_cron_service.py` |
+| Cron `_save_store` OSError resilience | [#22](https://github.com/Athemis/nanobot-redux/pull/22) | Cron service | `write_text()` or `stat()` in `_save_store` could raise `OSError` (disk full, permission error), propagating through `_on_timer` and killing the `tick()` asyncio task before `_arm_timer()` is called — permanently stopping the cron loop. Wraps both calls in `try/except OSError` with error logging; `_store_mtime` is only updated on success. | low | 2026-02-18 | `pytest tests/test_cron_service.py` |
+
+### Template for New Entries
+
+```markdown
+| Description | [#N](https://github.com/Athemis/nanobot-redux/pull/N) or [abc1234](https://github.com/Athemis/nanobot-redux/commit/abc1234) | Area | Why | low | YYYY-MM-DD | `pytest tests/...` |
+```
+
+**Columns:**
+
+- **Change**: Short description of what changed
+- **PR/Commit**: Link to the PR or the key implementation commit in this fork
+- **Area**: What part of the codebase (Codex Provider, Email channel, CI, etc.)
+- **Why**: Rationale — what problem it solves or what invariant it enforces
+- **Risk**: `low`, `medium`, or `high` — maintenance/security assessment
+- **Added**: Date merged into `main` (YYYY-MM-DD)
+- **Verification**: How to verify it works
+
+## Notes
+
+- **Not everything is logged**: Minor docs tweaks, workspace content edits, and style-only changes don't get entries.
+- **Dates are merge dates**: When the change landed in `main`, not when it was authored.
+- **Risk is subjective**: Assessed for maintenance burden and security impact.
+
+## Related Documentation
+
+- [`docs/upstream-log.md`](upstream-log.md) - Upstream adoptions, deferrals, and rejections
+- [`docs/redux-manifest.md`](redux-manifest.md) - Fork philosophy and priorities
+- [`docs/upstream-intake.md`](upstream-intake.md) - How upstream changes are evaluated
+- [`docs/release-template.md`](release-template.md) - Release checklist


### PR DESCRIPTION
## Summary

- Moves Redux-specific changes out of `docs/upstream-log.md` into a new dedicated `docs/redux-changes.md`, keeping upstream adoption tracking separate from fork-originated changes
- Adds \"What This Fork Adds\" section to README with fork-only improvements (not upstream-adopted)
- Fixes README git clone URL (pointed to upstream instead of fork)
- Adds `nanobot cron add --tz` and `--at` CLI examples to README cron section
- Updates `AGENTS.md` to reference `redux-changes.md` in project structure and intake instructions

## Rationale

Fork-specific changes (security hardening, cron hot-reload, subagent skill access, CI lint) were mixed into `upstream-log.md` alongside upstream adoption records. Separating them makes both files cleaner and easier to navigate: `upstream-log.md` answers "what did we take from upstream?", `redux-changes.md` answers "what did we build ourselves?".

## Test Evidence

- `ruff check .` — no issues (docs-only change)
- `pytest` — all tests pass (no code changes)

## Files Changed

- `docs/redux-changes.md` — new file, all fork-specific changes with PR/commit links
- `docs/upstream-log.md` — removed Redux-Specific Changes section, added cross-references
- `README.md` — clone URL fix, cron examples, "What This Fork Adds" section
- `AGENTS.md` — references to `redux-changes.md`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to point to the new repository clone.
  * Expanded Cron docs with renamed action, examples for recurring/one-time/timezone-aware/interval jobs, and note about automatic pickup within ≤5 minutes.
  * Added a new ledger of fork-specific Redux changes and linked it from upstream/adoption docs.
  * Expanded philosophy and fork-specific guidance; removed the prior Contributing section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->