### PR TITLE
feat(docker): adopt upstream #765 Docker Compose deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,6 +544,39 @@ nanobot cron remove <job_id>
 >
 > The default `Dockerfile` uses a multi-stage Alpine build (`python:3.14-alpine`) and includes Matrix E2EE dependencies (`olm`, `olm-dev`). It also sets `CMAKE_POLICY_VERSION_MINIMUM=3.5` to keep `python-olm` builds working with Alpine 3.23's CMake 4.
 
+### Using Docker Compose (Recommended)
+
+The easiest way to run nanobot with Docker:
+
+```bash
+# 1. Initialize config (first time only)
+docker compose run --rm nanobot-cli onboard
+
+# 2. Edit config to add API keys
+vim ~/.nanobot/config.json
+
+# 3. Start gateway service
+docker compose up -d nanobot-gateway
+
+# 4. Check logs
+docker compose logs -f nanobot-gateway
+
+# 5. Run CLI commands
+docker compose run --rm nanobot-cli status
+docker compose run --rm nanobot-cli agent -m "Hello!"
+
+# 6. Stop services
+docker compose down
+```
+
+**Features:**
+- ✅ Resource limits (1 CPU, 1GB memory)
+- ✅ Auto-restart on failure
+- ✅ Shared configuration using YAML anchors
+- ✅ Separate CLI profile for on-demand commands
+
+### Using Docker directly
+
 Build and run nanobot in a container:
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,32 @@
+x-common-config: &common-config
+  build:
+    context: .
+    dockerfile: Dockerfile
+  volumes:
+    - ~/.nanobot:/root/.nanobot
+
+services:
+  nanobot-gateway:
+    container_name: nanobot-gateway
+    <<: *common-config
+    command: ["gateway"]
+    restart: unless-stopped
+    ports:
+      - 18790:18790
+    deploy:
+      resources:
+        limits:
+          cpus: '1'
+          memory: 1G
+        reservations:
+          cpus: '0.25'
+          memory: 256M
+  
+  nanobot-cli:
+    container_name: nanobot-cli
+    <<: *common-config
+    profiles:
+      - cli
+    command: ["status"]
+    stdin_open: true
+    tty: true


### PR DESCRIPTION
## Summary

Cherry-pick of upstream [#765](https://github.com/HKUDS/nanobot/pull/765) (commit `c03f2b6`), signed.

- Adds `docker-compose.yml` with two services:
  - `nanobot-gateway`: persistent gateway with restart policy and resource limits (1 CPU / 1 GB memory)
  - `nanobot-cli`: on-demand CLI access via `--profile cli`
- Adds "Using Docker Compose" section to the Docker chapter in README

No conflicts — cherry-pick applied cleanly.

## Test Evidence

- `ruff check .` — no issues
- `pytest` — 207 passed

Manual smoke test: `docker compose build && docker compose run --rm nanobot-cli status`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)