### PR TITLE
feat(cli): adopt upstream #746 — wire CronService into CLI agent

### DIFF
--- a/nanobot/cli/commands.py
+++ b/nanobot/cli/commands.py
@@ -462,12 +462,17 @@ def agent(
 
     from nanobot.agent.loop import AgentLoop
     from nanobot.bus.queue import MessageBus
-    from nanobot.config.loader import load_config
+    from nanobot.config.loader import get_data_dir, load_config
+    from nanobot.cron.service import CronService
 
     config = load_config()
 
     bus = MessageBus()
     provider = _make_provider(config)
+
+    # Create cron service for tool usage (no callback needed for CLI unless running)
+    cron_store_path = get_data_dir() / "cron" / "jobs.json"
+    cron = CronService(cron_store_path)
 
     if logs:
         logger.enable("nanobot")
@@ -485,6 +490,7 @@ def agent(
         memory_window=config.agents.defaults.memory_window,
         web_search_config=config.tools.web.search,
         exec_config=config.tools.exec,
+        cron_service=cron,
         restrict_to_workspace=config.tools.restrict_to_workspace,
         mcp_servers=config.tools.mcp_servers,
     )


### PR DESCRIPTION
## Summary

Cherry-pick of upstream [#746](https://github.com/HKUDS/nanobot/pull/746) (commit `778a933`), signed.

Wires `CronService` into the interactive `nanobot agent` CLI command — previously only the gateway had access to the cron tool.

Conflict resolved: upstream used `brave_api_key` and different import order; kept fork's `web_search_config` parameter and `loguru`-first import style.

`CronService` is not started (no `cron.start()` / `on_job` callback) — the CLI event loop doesn't run indefinitely. Jobs can be created and inspected interactively; execution only happens via `nanobot gateway`.

## Test Evidence

- `ruff check nanobot/cli/commands.py` — no issues
- `pytest` — 207 passed

🤖 Generated with [Claude Code](https://claude.ai/claude-code)