### PR TITLE
docs(readme): update real-time line count to 4,010

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ⚡️ Delivers core agent functionality in just **~4,000** lines of code — **99% smaller** than Clawdbot's 430k+ lines.
 
-📏 Real-time line count: **3,851 lines** (run `bash core_agent_lines.sh` to verify anytime)
+📏 Real-time line count: **4,010 lines** (run `bash core_agent_lines.sh` to verify anytime)
 
 ## 📍 Fork Baseline
 


### PR DESCRIPTION
## Summary

Updates the real-time line count badge from 3,851 to **4,010** lines, reflecting the current output of `bash core_agent_lines.sh` after the providers refactor in #33 (OpenAIProvider added, LiteLLMProvider and CustomProvider removed).

## Test plan

- [x] `bash core_agent_lines.sh` → `Core total: 4010 lines`

🤖 Generated with [Claude Code](https://claude.ai/code)